### PR TITLE
list/index.php: search when hitting back

### DIFF
--- a/list/index.php
+++ b/list/index.php
@@ -1,17 +1,15 @@
 <html>
 <head>
-  <title>Opening list</title>
+  <title>Video list</title>
   <link rel="stylesheet" type="text/css" href="markdown.css">
   <meta charset="UTF-8">
   <meta name=viewport content="width=device-width, initial-scale=1">
 </head>
-<body>
+<body onload="loadListIntoJavascript()" onpageshow="search()">
 
 <a href="../hub"><< Back to the hub</a>
 
-<h1>Messy video list</h1>
-
-<p>Hint: ctrl+f</p>
+<h1>Video list</h1>
 
 <?php
 
@@ -30,27 +28,29 @@ echo '<p>We currently serve <span style="color:#2ECC40">' . $videosnumber . '</s
 
 ?>
 
+<span>Search: </span><input id="searchbox" type="text" onkeyup="search()"><br><br>
+
 <br />
 
 <?php
 
 foreach ($series as $key => $opening) {
-	// Series
-	echo '<div class="series">' . $key;
+        // Series
+        echo '<div class="series">' . $key;
 
-	// List
-	echo '<ul>' . PHP_EOL . PHP_EOL;
-	foreach ($opening as $video) { //Hey, I heard you like new lines
-		echo '  <a href="../?video=' . $video["filename"] . '">' . PHP_EOL
-		. '    <div class="title">' . PHP_EOL
-		. '      - ' . $video["title"] . PHP_EOL
-		. '    </div>' . PHP_EOL
-		. '  </a>' . PHP_EOL . PHP_EOL
-		. '  <br />' . PHP_EOL
-		. PHP_EOL;
-	}
+        // List
+        echo '<ul>' . PHP_EOL . PHP_EOL;
+        foreach ($opening as $video) { //Hey, I heard you like new lines
+                echo '  <a href="../?video=' . $video["filename"] . '">' . PHP_EOL
+                . '    <div class="title">' . PHP_EOL
+                . '      - ' . $video["title"] . PHP_EOL
+                . '    </div>' . PHP_EOL
+                . '  </a>' . PHP_EOL . PHP_EOL
+                . '  <br />' . PHP_EOL
+                . PHP_EOL;
+        }
 
-	echo '</ul>' . PHP_EOL . '</div>' . PHP_EOL . PHP_EOL;
+        echo '</ul>' . PHP_EOL . '</div>' . PHP_EOL . PHP_EOL;
 
   //echo '<div class="opening"><p class="source">' . $opening["source"] . ' - </p><a href="../?video=' . $key . '"><p class="title">' . $opening["title"] . '</p></a></div>' . PHP_EOL;
 }
@@ -58,6 +58,36 @@ foreach ($series as $key => $opening) {
 include_once('../backend/includes/botnet.html');
 
 ?>
+
+<!-- Searchbox Code -->
+    <script type="text/javascript">
+      function loadListIntoJavascript()
+      {
+        list = document.getElementsByClassName('series');
+
+        if ( location.search.indexOf('=') > -1 )
+          document.getElementById('searchbox').value = location.search.substring(location.search.indexOf('=')+1);
+      }
+
+      function search()
+      {
+        var toFind = document.getElementById('searchbox').value.toUpperCase().split(' ');
+        
+        for ( i = 0; i < list.length; ++i )
+        {
+          for ( j = 0; j < toFind.length; ++j )
+          {
+            if ( list[i].textContent.toUpperCase().substring(0,list[i].textContent.indexOf('\n')).indexOf(toFind[j]) !== -1 ) list[i].removeAttribute('hidden','');
+            
+            else
+            {
+              list[i].setAttribute('hidden','');
+              break;
+            }
+          }
+        }
+      }
+    </script>
 
 </body>
 </html>


### PR DESCRIPTION
This fix is from Yay295.

already deployed to production.

from #aniop:
00:57  theholyduck » i have a feature request thingy in terms of search
00:57  theholyduck » if i search for something in the search bar
00:58  theholyduck » it works fine, but if i click a video, and then go back to the main page
00:58  theholyduck » the text stays in the search bar, but i have to interact with it
00:58  theholyduck » to make it do the search again
00:58  theholyduck » is there some way to make it revert back to the searched selection when i press back
00:58  theholyduck » like, how every other search function generally works?
01:52  Yay295 » @quad: Search Fixes -> https://drive.google.com/open?id=0B3T4eWH7NVj7aWowcEkwZXRIdGc&authuser=0