### PR TITLE
Patch 2

### DIFF
--- a/CSS/main.css
+++ b/CSS/main.css
@@ -13,9 +13,6 @@ body {
 body:fullscreen {
   background-color: #111;
 }
-body:-moz-full-screen {
-  background-color: #111;
-}
 body:-ms-fullscreen {
   background-color: #111;
 }
@@ -125,7 +122,7 @@ video {
 
 #closemenubutton {
   color: black;
-  text-shadow: unset;
+  text-shadow: inherit;
 }
 
 #site-menu {

--- a/main.js
+++ b/main.js
@@ -206,7 +206,7 @@ function playPause() {
 
   // Toggle Tooltip
   tooltip();
-  tooltip("pause-button", "right");
+  tooltip("pause-button");
 
   // Toggle Play/Pause Icon
   $("#pause-button").toggleClass("fa-play").toggleClass("fa-pause");
@@ -231,6 +231,10 @@ function skip(value) {
 function toggleFullscreen() {
   if (isFullscreen()) exitFullscreen();
   else enterFullscreen();
+
+  // Toggle Tooltip
+  tooltip();
+  tooltip("fullscreen-button");
 }
 function exitFullscreen() {
   if (document.exitFullscreen) document.exitFullscreen();
@@ -454,6 +458,7 @@ $(window).konami({
     $("#skip-left").toggleClass("fa-spin");
     $("#skip-right").toggleClass("fa-spin");
     $("#pause-button").toggleClass("fa-spin");
+    $("#fullscreen-button").toggleClass("fa-spin");
 
     keylog = []
 


### PR DESCRIPTION
CSS/main.css:
Removed body:-moz-full-screen becuase Firefox handles it correctly anyway.
Changed #closemenubutton's text-shadow property so it works on Edge.

main.js:
Added fullscreen button to Secret~.
Made tooltip text change on click.
Removed obsolete tooltip CSS-setter in playPause().