### PR TITLE
Fix a bunch of bugs I introduced by changing to json

### DIFF
--- a/index.php
+++ b/index.php
@@ -105,7 +105,7 @@
       <span id="song">
         <?php
         // If we have the data, echo it
-        if (array_key_exists("song", $videos[$filename])) {
+        if (array_key_exists("song", $videos[$filename]) && ($videos[$filename]["song"] != 0)) {
           echo "Song: &quot;" . $videos[$filename]["song"]["title"] . "&quot; by " . $videos[$filename]["song"]["artist"];
         }
         else { // Otherwise, let's just pretend it never existed... or troll the user.

--- a/index.php
+++ b/index.php
@@ -18,7 +18,7 @@
     die;
   }
 
-  $subtitlesAvailable = (array_key_exists($filename, $videos) && isset($videos[$filename]["subtitles"]) && $videos[$filename]["subtitles"] != 0);
+  $subtitlesAvailable = (array_key_exists($filename, $videos) && isset($videos[$filename]["subtitles"]) && ($videos[$filename]["subtitles"] !== 0));
   $subtitleAttribution = $subtitlesAvailable ? (" (Source: " . $videos[$filename]["subtitles"]) . ")" : "";
 ?>
 <!DOCTYPE html>
@@ -105,7 +105,7 @@
       <span id="song">
         <?php
         // If we have the data, echo it
-        if (array_key_exists("song", $videos[$filename]) && ($videos[$filename]["song"] != 0)) {
+        if (array_key_exists("song", $videos[$filename]) && ($videos[$filename]["song"] !== 0)) {
           echo "Song: &quot;" . $videos[$filename]["song"]["title"] . "&quot; by " . $videos[$filename]["song"]["artist"];
         }
         else { // Otherwise, let's just pretend it never existed... or troll the user.

--- a/list/index.php
+++ b/list/index.php
@@ -61,8 +61,8 @@
 			// List
 			foreach ($video_array as $video) {
 				echo '	<i class="fa fa-plus"';
-					if (isset($video["song"])) echo ' songTitle="' . $video["song"]["title"] . '" songArtist="' . $video["song"]["artist"] . '"';
-					if (isset($video["subtitles"]) && $video["subtitles"] != 0) echo ' subtitles="' . $video["subtitles"] . '"';
+					if (isset($video["song"]) && $video["song"] !== 0) echo ' songTitle="' . $video["song"]["title"] . '" songArtist="' . $video["song"]["artist"] . '"';
+					if (isset($video["subtitles"]) && $video["subtitles"] !== 0) echo ' subtitles="' . $video["subtitles"] . '"';
 				echo '></i>' . PHP_EOL;
 				echo '	<a href="../?video=' . $video["filename"] . '">' . $video["title"] . "</a>" . PHP_EOL;
 				echo "	<br />" . PHP_EOL;

--- a/names.php
+++ b/names.php
@@ -399,4 +399,4 @@ function compare_openings($a, $b) {
 
 	return 0;
 }
-uasort($names,compare_openings);
+uasort($names,"compare_openings");


### PR DESCRIPTION
Having not properly tested index.php, I didn't spot some of the issues with the json migration.

This pull fixes:
 - Subtitles availability not being recognised
 - `Song: "" by ` being displayed when song metadata unavailable
 - "Use of undefined constant compare_openings - assumed 'compare_openings' in /var/www/html/names.php on line 406" filling up the error_logs.