### PR TITLE
Added localstorage saving of variables such as autonext and openingsonly

### DIFF
--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ var autonext = false;
 var OPorED = "all"; // egg, op, ed, all
 var xDown = null, yDown = null; // position of mobile swipe start location
 var mouseIdle, lastMousePos = {"x":0,"y":0};
+var storageSupported = false;
 
 function filename() { return document.getElementsByTagName("source")[0].src.split("video/")[1].split(".")[0]; }
 function title() { return document.getElementById("title").textContent.trim(); }
@@ -42,6 +43,23 @@ window.onload = function() {
     }
   } else {
     popHist();
+  }
+  
+  if ("localStorage" in window && window["localStorage"] !== null) {
+    storageSupported = true;
+  }
+  
+  if (storageSupported) {
+    if (window.localStorage["autonext"] == "true") {
+      toggleAutonext();
+    }
+    if (window.localStorage["openingsonly"] == "op") {
+      toggleOpeningsOnly();
+    }
+    else if (window.localStorage["openingsonly"] == "ed") {
+      toggleOpeningsOnly();
+      toggleOpeningsOnly();
+    }
   }
 
   // Fix menu button. It is set in HTML to be a link to the FAQ page for anyone who has disabled JavaScript.
@@ -358,6 +376,9 @@ function toggleAutonext() {
     $("#autonext").removeClass("fa-toggle-on").addClass("fa-toggle-off");
     document.getElementById("bgvid").setAttribute("loop", "");
   }
+  if (storageSupported) {
+    window.localStorage["autonext"] = autonext;
+  }
 
   // Toggle Tooltip
   tooltip();
@@ -386,6 +407,9 @@ function toggleOpeningsOnly () {
     element.classList.remove("fa-circle-o");
     element.classList.remove("fa-adjust");
     element.classList.add("fa-circle");
+  }
+  if (storageSupported) {
+    window.localStorage["openingsonly"] = OPorED;
   }
 
   // Toggle Tooltip


### PR DESCRIPTION
Not tested yet, but I think this should work based on small unit testing.

Basically, this just stores the state of "autonext" and "openingsonly" in local storage so that it remembers the values the next time the user visits the site. I always like to keep autonext on and not having to press the button every time I reload the page would be a nice improvement.