### PR TITLE
Update encode.py

### DIFF
--- a/encode/encode.py
+++ b/encode/encode.py
@@ -69,8 +69,8 @@ def calcVolumeAdjustment():
     # ffmpeg [-ss <start>] -i <source> [-to <end>] -af "volumedetect" -f null /dev/null
     with open(outputFile + ".log", "x") as f:
         args = ["ffmpeg"]
-        if (startTime != ""): args += ["-ss", startTime]
         args += ["-i", inputFile]
+        if (startTime != ""): args += ["-ss", startTime]
         if (endTime != ""): args += ["-to", endTime]
         args += ["-af", "volumedetect", "-f", "null", getNullObject()]
         subprocess.call(args, stdin=None, stdout=f, stderr=f)
@@ -92,11 +92,11 @@ def getFFmpegConditionalArgs():
     args = []
     if (shutUp):
         args += ["-loglevel", "panic"]
-    if (startTime != ""):
-        args += ["-ss", startTime]
 
     args += ["-i", inputFile]
-
+    
+    if (startTime != ""):
+        args += ["-ss", startTime]
     if (endTime != ""):
         args += ["-to", endTime]
 


### PR DESCRIPTION
move -ss after -i.

encode.py called with -s 00:01:00 -e 00:02:00 should create a one minute long video starting from 00:01:00 and ending at 00:02:00.

If -ss is before -i, it seeks to the -ss time, and that time is interpreted as 0.