### PR TITLE
fix loading bar bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -71,6 +71,7 @@ window.onload = function() {
 
   // Progress bar event listeners
   video.addEventListener("progress", updateprogress); // on video loading progress
+  video.addEventListener("timeupdate", updateprogress);
   video.addEventListener("timeupdate", updateplaytime); // on time progress
 
   // Progress bar seeking


### PR DESCRIPTION
The loading bar was only updated when the `progress` event fired, but that event doesn't fire when you aren't looking at the page (at least in Firefox), so if the video finished loading when you weren't looking at it, the bar wouldn't update any more.