### PR TITLE
Fix video title opacity

### DIFF
--- a/JS/main.js
+++ b/JS/main.js
@@ -589,6 +589,7 @@ function showVideoTitle(delay) {
 	clearTimeout(showVideoTitleTimeoutB);
 
 	popup.innerHTML = video.title + " from " + video.source;
+	popup.style.opacity = 0;
 
 	showVideoTitleTimeoutA = setTimeout(() => {
 		popup.style.opacity = 1;


### PR DESCRIPTION
When switching from one video to another while having the old title visible, the new title would have been display without any delay.