### PR TITLE
Added option to identify songs by their full filename

### DIFF
--- a/JS/main.js
+++ b/JS/main.js
@@ -30,6 +30,9 @@ function filenameToIdentifier(filename) {
 	// Replace % escapes with their actual characters.
 	filename = decodeURIComponent(filename);
 
+	// If we use the filename as identifier.
+	if(window.n_dont_parse_filename) return filename;
+
 	// Array(...filename parts, {OP,IN,ED}{0,1,2,...}[{a,b,c,...}], [N]C{BD,DVD,PC,...})
 	let parts = filename.split("-");
 

--- a/backend/includes/helpers.php
+++ b/backend/includes/helpers.php
@@ -16,6 +16,9 @@ function mimeToExt($mime) {
 }
 
 function filenameToIdentifier($filename) {
+	global $N_DONT_PARSE_FILENAME;
+	if(isset($N_DONT_PARSE_FILENAME) && $N_DONT_PARSE_FILENAME) return rawurlencode($filename);
+
 	$parts = explode('-', $filename);
 
 	// [N]C{BD,DVD,PC,...}[.{webm,mp4,...}]
@@ -38,6 +41,9 @@ function filenameToIdentifier($filename) {
 function identifierToPartialFilename($ident) {
 	// decode the identifier, replacing percent-escapes with their actual characters
 	$ident = rawurldecode($ident);
+
+	global $N_DONT_PARSE_FILENAME;
+	if(isset($N_DONT_PARSE_FILENAME) && $N_DONT_PARSE_FILENAME) return $ident;
 
 	// [{Opening,Insert,Ending}{1,2,...}[{a,b,c,...}], ...filename parts]
 	$parts = explode('-', $ident);

--- a/index.php
+++ b/index.php
@@ -3,6 +3,10 @@
 
 	include_once 'names.php';
 
+	// If N_DONT_PARSE_FILENAME is not set in the config.php file, set it to false.
+	global $N_DONT_PARSE_FILENAME;
+	if(!isset($N_DONT_PARSE_FILENAME)) $N_DONT_PARSE_FILENAME = FALSE;
+
 	// check if a specific video has been requested
 	if (isset($_GET['video'])) {
 		// get raw query so it doesn't try to parse the reserved characters (;/?:@&=+,$)
@@ -112,6 +116,9 @@
 		<link rel="stylesheet" type="text/css" href="CSS/main.css">
 		<link rel="stylesheet" type="text/css" href="CSS/fonts.css">
 		<link rel="stylesheet" type="text/css" href="CSS/subtitles.css">
+		<script type="text/javascript">
+		window.n_dont_parse_filename = ( <?php echo($N_DONT_PARSE_FILENAME ? "1":"0");?> == "1" );
+		</script>
 		<script src="JS/main.js"></script>
 		<script defer src="JS/subtitles.js"></script>
 


### PR DESCRIPTION
Hello there.

I promised an issue about this, but soeone on our side did make a patch so I'm submitting it as a pull request on behalf of the Karaoke Mugen team.

The main issue is that with AO's current parsing of the song name, we had a problem where songs of the same type and series would never be able to be selected or linked.

Example : 
```
JAP - µ's - LIVE - Aki no Anata no Sora Tooku.mp4
JAP - µ's - LIVE - Cutie panther.mp4
JAP - µ's - LIVE - Dancing stars on me!.mp4
JAP - µ's - LIVE - Glass no Hanazono.mp4
JAP - µ's - LIVE - Snow halation.mp4
JAP - µ's - LIVE - Start DASH.mp4
``` 

In this use case, there are no numbers to differenciate the songs, other than their titles. What happened was that, when selecting Start DASH in AnimeOpenings, it always redirected to Aki no... since it was the first song in it slist.

The patch creates a new variable you can set to true in the config file to keep AnimeOpenings from trying to parse the filename before givng it to the user. The filename is extracted as is in the URL and AnimeOPening's able to select that song when a user clicks on it.

We made it a variable so you can use either use AO's original way or this one.

The main problem is that `filenameToIdentifier` loses some information on how it parses the file to an identifier, and when `identifierToPartialFilename` kicks in, it can't retrieve all the information.

Feel free to change anything in the code if needs be, this is a real quick fix, and might not fit with your coding habits.

If you have questions before merging this, I'll answer them :)

Hope to see this merged in sometime :)

