### PR TITLE
Add support for ?autoplay parameter

### DIFF
--- a/JS/main.js
+++ b/JS/main.js
@@ -82,6 +82,10 @@ window.onload = function() {
 	let GPB = DID("giant-play-button");
 	GPB.style.display = "block";
 
+	// Get autoplay param prior to updating history
+    	const params = 'URLSearchParams' in window ? new URLSearchParams(location.search) : undefined;
+    	const autoplayParam = params && params.get('autoplay');
+	
 	// Set/Get history state
 	if (history.state == null) {
 		var video = {file: filename(),
@@ -142,7 +146,9 @@ window.onload = function() {
 	setupPlayerJS();
 
 	// autoplay
-	if (!inIFrame) playVideo();
+	const requestedAutoplay = autoplayParam === 'true' || autoplayParam === '1';
+    	const shouldAutoplay = requestedAutoplay || !inIFrame;
+	if (shouldAutoplay) playVideo();
 };
 
 window.onpopstate = popHist;


### PR DESCRIPTION
Loading any openings.moe link with `?autoplay=1` or `?autoplay=true` will now autoplay the video. This includes the site being embedded in an IFrame. The parameter name `autoplay` is the same as what's used in other media websites such as YouTube.

e.g. https://openings.moe/?video=Opening4a-Bakemonogatari&autoplay=true

Context: I'm creating [an application to sync up videos](https://github.com/samuelmaddock/metastream) on the web. I want to use openings.moe, but it won't autoplay videos in an iframe without requiring injecting scripts.