### PR TITLE
Fix group is null exception

### DIFF
--- a/JS/subtitles.js
+++ b/JS/subtitles.js
@@ -2396,7 +2396,8 @@ let SubtitleManager = (function() {
 					}
 				}
 
-				this.group.remove();
+				if(this.group)
+					this.group.remove();
 				this.group = null;
 
 				this.updates = null;

--- a/JS/subtitles.js
+++ b/JS/subtitles.js
@@ -2396,7 +2396,7 @@ let SubtitleManager = (function() {
 					}
 				}
 
-				if(this.group)
+				if (this.group)
 					this.group.remove();
 				this.group = null;
 


### PR DESCRIPTION
This is part of Karaoke Mugen's team's efforts to push back some of our changes to AO (and as a thanks for all the bugs fixed)

This exception happens when watching several videos with subs one after the other

