### PR TITLE
Add jingles option to AO

### DIFF
--- a/JS/main.js
+++ b/JS/main.js
@@ -368,8 +368,12 @@ function setVideoElements() {
 	const filename = rawurlencodePHP(decodeURIComponent(video.file));
 
 	var sources = "";
-	for (let mime of video.mime)
-		sources += '<source src="video/' + filename + mimeToExt(mime) + '" type="' + mime + '">';
+	for (let mime of video.mime) {
+		if(video.title == "Jingle time!" && video.egg)
+			sources += '<source src="jingles/' + filename + mimeToExt(mime) + '" type="' + mime + '">';
+		else
+			sources += '<source src="video/' + filename + mimeToExt(mime) + '" type="' + mime + '">';
+	}
 	VideoElement.innerHTML = sources;
 	VideoElement.load();
 	DID("subtitle-attribution").innerHTML = (video.subtitles ? "[" + video.subtitles + "]" : "");

--- a/api/list.php
+++ b/api/list.php
@@ -11,6 +11,18 @@ include_once '../backend/includes/helpers.php';
 include_once '../names.php';
 $videos = $names;
 
+$jinglesFiles;
+// Get jingles list from the jingles directory
+if(isset($JINGLES_INTERVAL) && $JINGLES_INTERVAL > 0) {
+	foreach(glob("../jingles/*.mp4") as $jingle) {
+		$jinglesFiles[] = str_replace(".mp4", "", str_replace("../jingles/", "", $jingle));
+	}
+}
+$nbJingles = count($jinglesFiles);
+if($nbJingles > 0) {
+	shuffle($jinglesFiles);
+}
+
 // Remove Easter Eggs if they weren't requested.
 if (!isset($_GET['eggs'])) {
 	foreach ($videos as $series => $video_array) {
@@ -42,7 +54,12 @@ if (isset($_GET['filenames'])) {
 	}
 } else {
 	if (isset($_GET['shuffle'])) {
+		$i = 1; //Counts from 1 and not zero to take into account the initial off-list video.
+		$j = 0;
 		while (!empty($videos)) {
+
+			$i++;
+			
 			$series = array_rand($videos);
 			$title = array_rand($videos[$series]);
 
@@ -56,6 +73,22 @@ if (isset($_GET['filenames'])) {
 				'subtitles' => existsOrDefault('subtitles', $data),
 				'egg' => existsOrDefault('egg', $data)
 			];
+			if($nbJingles > 0 && ($i % $JINGLES_INTERVAL) == 0) {
+				$output[] = [
+					'title' => "Jingle time!",
+					'source' => "Karaoke Mugen",
+					'file' => $jinglesFiles[$j],
+					'mime' => $data['mime'],
+					'song' => "Jingle",
+					'subtitles' => null,
+					'egg' => "true"
+				];
+
+				$j++;
+				if(($j % $nbJingles) == 0) {
+					$j = 0;
+				}
+			}
 
 			end($output);
 			$last = &$output[key($output)];


### PR DESCRIPTION
This is part of Karaoke Mugen's team's efforts to push back some of our changes to AO (and as a thanks for all the bugs fixed)

Jingles are video files in the "jingles" directory.

They are only played if JINGLES_INTERVAL is set and > 0

Jingles can be used to display small, funny spots or ads/promotions

